### PR TITLE
Update to latest upstream

### DIFF
--- a/.environment
+++ b/.environment
@@ -1,22 +1,132 @@
-# Initial admin user on first deploy.
-export INIT_ADMINUSER='admin@example.com'
-export INIT_ADMINPW='password'
+####################################################################################################
+# General
 
-# Public url for the current Platform.sh environment.
-export PUBLIC_URL=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.primary == true) | .key')
+# Public url for the current Platform.sh environment. Remove trailing slash.
+ENVIRONMENT=$(echo $PLATFORM_ROUTES | base64 --decode | jq -r 'to_entries[] | select(.value.primary == true) | .key')
+export PUBLIC_URL=${ENVIRONMENT%/}
+export LOG_STYLE="pretty"
+if [ "$PLATFORM_BRANCH" != "master" ] ; then
+    export LOG_LEVEL="silent"
+else
+    export LOG_LEVEL="silent"
+fi
 
-# Database credentials.
+####################################################################################################
+# Database
+
+export DB_CLIENT="pg"
 export DB_HOST=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".database[0].host")
 export DB_PORT=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".database[0].port")
 export DB_DATABASE=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".database[0].path")
 export DB_USER=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".database[0].username")
 export DB_PASSWORD=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".database[0].password")
 
+####################################################################################################
+# Rate Limiting
+
+export RATE_LIMITER_ENABLED=true
+
+export RATE_LIMITER_POINTS=50
+export RATE_LIMITER_DURATION=1
+
+export RATE_LIMITER_STORE=memcache
+
+## Memcache (see https://github.com/animir/node-rate-limiter-flexible/wiki/Memcache and
+##               https://www.npmjs.com/package/memcached)
+MEMCACHE_HOST=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".memcachedcache[0].host")
+MEMCACHE_PORT=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".memcachedcache[0].port")
+export RATE_LIMITER_MEMCACHE="${MEMCACHE_HOST}:${MEMCACHE_PORT}"
+
+####################################################################################################
+# Caching
+
+export CACHE_ENABLED=true
+export CACHE_TTL="30m"
+export CACHE_NAMESPACE="directus-cache"
+export CACHE_STORE=redis
+export CACHE_AUTO_PURGE=true
+
+export ASSETS_CACHE_TTL="30m"
+
+export CACHE_REDIS_HOST=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".rediscache[0].host")
+export CACHE_REDIS_PORT=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".rediscache[0].port")
+export CACHE_REDIS_PASSWORD=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".rediscache[0].password")
+export CACHE_REDIS_DB=$(echo $PLATFORM_RELATIONSHIPS | base64 --decode | jq -r ".rediscache[0].path")
+
+####################################################################################################
+# File Storage
+
+export STORAGE_LOCATIONS="local" # CSV of names
+
+export STORAGE_LOCAL_PUBLIC_URL="${PUBLIC_URL}uploads"
+export STORAGE_LOCAL_DRIVER="local"
+export STORAGE_LOCAL_ROOT="./uploads"
+
+## S3 Example (location name: DigitalOcean)
+# STORAGE_DIGITALOCEAN_DRIVER="s3"
+# STORAGE_DIGITALOCEAN_PUBLIC_URL="https://cdn.example.com/"
+# STORAGE_DIGITALOCEAN_KEY="abcdef"
+# STORAGE_DIGITALOCEAN_SECRET="ghijkl"
+# STORAGE_DIGITALOCEAN_ENDPOINT="ams3.digitaloceanspaces.com"
+# STORAGE_DIGITALOCEAN_BUCKET="my-files"
+# STORAGE_DIGITALOCEAN_REGION="ams3"
+
+## Google Cloud Storage Example (location name: Google)
+# STORAGE_GOOGLE_DRIVER="gcs"
+# STORAGE_GOOGLE_PUBLIC_URL="https://cdn.example.com/"
+# STORAGE_GOOGLE_KEY_FILENAME="abcdef"
+# STORAGE_GOOGLE_BUCKET="my-files"
+
+####################################################################################################
+# Security
+
 # Using project entropy for Directus secret keys.
 export KEY=$PLATFORM_PROJECT_ENTROPY
 export SECRET=$PLATFORM_PROJECT_ENTROPY
+export ACCESS_TOKEN_TTL="15m"
+export REFRESH_TOKEN_TTL="7d"
+export REFRESH_TOKEN_COOKIE_SECURE="false"
+export REFRESH_TOKEN_COOKIE_SAME_SITE="lax"
 
-# Upstream parsing issue fix.
-export STORAGE_LOCATIONS="local"
-# Use environment url for public uploads url.
-export STORAGE_LOCAL_PUBLIC_URL="${PUBLIC_URL}uploads"
+export CORS_ENABLED="true"
+export CORS_ORIGIN=*
+export CORS_METHODS=GET,POST,PATCH,DELETE
+export CORS_ALLOWED_HEADERS=Content-Type,Authorization
+export CORS_EXPOSED_HEADERS=Content-Range
+export CORS_CREDENTIALS="true"
+export CORS_MAX_AGE=18000
+
+####################################################################################################
+# SSO (OAuth) Providers
+
+# OAUTH_PROVIDERS="github, facebook"
+
+# OAUTH_GITHUB_KEY="abcdef"
+# OAUTH_GITHUB_SECRET="ghijkl"
+
+# OAUTH_FACEBOOK_KEY="abcdef"
+# OAUTH_FACEBOOK_SECRET="ghijkl"
+
+####################################################################################################
+# Extensions
+
+export EXTENSIONS_PATH="./extensions"
+
+####################################################################################################
+# Email
+
+export EMAIL_FROM=no-reply@directus.io
+export EMAIL_TRANSPORT=smtp
+
+## Email (SMTP Transport)
+export EMAIL_SMTP_HOST=$PLATFORM_SMTP_HOST
+export EMAIL_SMTP_PORT=25
+
+####################################################################################################
+# Platform.sh
+
+export PROJECT_NAME='Directus on Platform.sh'
+
+# Initial admin user on first deploy.
+export INIT_ADMINUSER='admin@example.com'
+export INIT_ADMINPW='password'

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -7,7 +7,7 @@
 name: app
 
 # The runtime the application uses.
-type: nodejs:14
+type: nodejs:12
 
 # The relationships of the application with services or other applications.
 #
@@ -16,12 +16,22 @@ type: nodejs:14
 # side is in the form `<service name>:<endpoint name>`.
 relationships:
     database: "dbpostgres:postgresql"
+    rediscache: "cacheredis:redis"
+    memcachedcache: "cachemc:memcached"
 
 # The hooks that will be triggered when the package is deployed.
 hooks:
     build: |
-        cp node_modules/directus/example.env .env
+        set -e
+        # Copy committed extensions and uploads to tmp directories so not overwritten by mount.
+        if [ -d extensions ]; then
+            mkdir extensions-tmp && mv extensions/* extensions-tmp
+        fi
+        if [ -d uploads ]; then
+            mkdir uploads-tmp && mv uploads/* uploads-tmp
+        fi
     deploy: |
+        set -e
         # Installs the database and sets up the initial admin user. Only run on first deploy.
         if [ ! -f var/platformsh.installed ]; then
             # Install the database
@@ -39,6 +49,15 @@ hooks:
             # Create file that indicates first deploy and installation has been completed.
             touch var/platformsh.installed
         fi;
+        # Copy committed extensions and uploads back onto writable mounts.
+        if [ -d extensions-tmp ]
+        then
+            cp -r extensions-tmp/* extensions
+        fi
+        if [ -d uploads-tmp ]
+        then
+            cp -r uploads-tmp/* uploads
+        fi
 
 # Start the Directus server. 
 web:
@@ -50,6 +69,9 @@ disk: 1024
 
 # Platform.sh write access at runtime.
 mounts:
+    'extensions':
+        source: local
+        source_path: extensions
     'uploads':
         source: local
         source_path: uploads

--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -6,3 +6,9 @@
 dbpostgres:
     type: postgresql:12
     disk: 256
+
+cacheredis:
+    type: redis:6.0
+
+cachemc:
+    type: memcached:1.6

--- a/README.md
+++ b/README.md
@@ -12,20 +12,52 @@ Directus is an open-source platform that allows you to create and manage an API 
 
 ## Features
 
-* Node.js 14
+* Node.js 12
 * PostgreSQL 12
+* Redis 6.0
+* Memcached 1.6 
 * Automatic TLS certificates
 * npm-based build
 
 ## Post-install
 
-This template does not require any additional configuration once deployed to start developing your Directus application. During the first deploy, however, an admin user was added to allow you to log in (see `.environment`). After you log in for the first time, be sure to update this password immediately. 
+### Admin user
+
+This template does not require any additional configuration once deployed to start developing your Directus application. During the first deploy, however, an admin user was added to allow you to log in. Those credentials are set (along with many other Platform.sh-specific settings) in the `.environment` file:
+
+```txt
+# Initial admin user on first deploy.
+export INIT_ADMINUSER='admin@example.com'
+export INIT_ADMINPW='password'
+```
+
+After you log in for the first time, be sure to update this password immediately. 
+
+### Database
 
 Although this project uses PostgreSQL as its primary database, Directus supports [a number of other options](https://docs.directus.io/guides/installation/cli.html#_1-confirm-minimum-requirements-are-met) that can be easily substituted using Platform.sh's managed services. 
 
 - [MariaDB](https://docs.platform.sh/configuration/services/mysql.html)
 - [Oracle MySQL](https://docs.platform.sh/configuration/services/mysql.html)
 - [PostgreSQL](https://docs.platform.sh/configuration/services/postgresql.html)
+
+### Logging
+
+The Directus CLI is used to create both a role UUID for admin users, and to use that UUID to create the initial admin user. Currently, having a `LOG_LEVEL` for Directus other than `silent` causes the log message to be included in the following line from the `.platform.app.yaml` file's deploy hook, resulting in a syntax error when creating that first user:
+
+```yaml
+ROLE_UUID=$(npx directus roles create --name admin --admin)
+```
+
+This is only something to be aware of on the first install, or when using a similar method for creating new users using the CLI. After you have deployed Directus and created the first admin user, you will likely want to update the `.environment` file to set more reasonable environment-dependent log messages:
+
+```txt
+if [ "$PLATFORM_BRANCH" != "master" ] ; then
+    export LOG_LEVEL="debug"
+else
+    export LOG_LEVEL="info"
+fi
+```
 
 ## Customizations
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
       "optional": true
     },
     "@azure/ms-rest-js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.9.0.tgz",
-      "integrity": "sha512-cB4Z2Mg7eBmet1rfbf0QSO1XbhfknRW7B+mX3IHJq0KGHaGJvCPoVTgdsJdCkazEMK1jtANFNEDDzSQacxyzbA==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.9.1.tgz",
+      "integrity": "sha512-F1crHKhmsvFLM9fsnDyCGFd2E2KR9GEZm5oBVV5D5k2EBQ7u7idtSJlSF6RDLDIrGWtc4NnFdYwsoiW8NLlBQg==",
       "optional": true,
       "requires": {
         "@types/tunnel": "0.0.0",
-        "axios": "^0.19.0",
+        "axios": "^0.21.1",
         "form-data": "^2.3.2",
         "tough-cookie": "^2.4.3",
         "tslib": "^1.9.2",
@@ -26,39 +26,6 @@
         "xml2js": "^0.4.19"
       },
       "dependencies": {
-        "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-          "optional": true,
-          "requires": {
-            "follow-redirects": "1.5.10"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "optional": true,
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "optional": true
-        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -79,31 +46,33 @@
       }
     },
     "@directus/app": {
-      "version": "9.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/@directus/app/-/app-9.0.0-rc.20.tgz",
-      "integrity": "sha512-dhrb+mIRDRrUwaRVJi+cL5cbRri5U2wbrh/sPAeI5xB9bTJocUAxHcjtYn3Tjrg2wbOHU58BOQ++dXnU6LyvRg=="
+      "version": "9.0.0-rc.32",
+      "resolved": "https://registry.npmjs.org/@directus/app/-/app-9.0.0-rc.32.tgz",
+      "integrity": "sha512-oMc6sLXwxFzRoJqWiPx8rLMkLLh5sRNcIENAzZO8s6kVjlZ627i9qJXRWqJRgVgNkJXPZeFBsb6eo7Y6wnc4Bw==",
+      "requires": {
+        "@directus/format-title": "^9.0.0-rc.32"
+      }
     },
     "@directus/format-title": {
-      "version": "9.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/@directus/format-title/-/format-title-9.0.0-rc.20.tgz",
-      "integrity": "sha512-PkE9RRgscJuzsifq9+yyeIAzjzsI3pGmBGX5zJUbMv2Pt3uM5HpyhMI0aLSO9+DQzvPBDt9cdDBKEznBhsb7WQ=="
+      "version": "9.0.0-rc.32",
+      "resolved": "https://registry.npmjs.org/@directus/format-title/-/format-title-9.0.0-rc.32.tgz",
+      "integrity": "sha512-PwEJ1RBpodCZlTQBJeHBGzku56FGPRn3k3ezjkPjP5JyVqP/1D2/ziXmVZgBZ+LQH0cYPhFTIVvgjHAyqtDY2Q=="
     },
     "@directus/schema": {
-      "version": "9.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/@directus/schema/-/schema-9.0.0-rc.20.tgz",
-      "integrity": "sha512-NqqqUQBbakycRAJ4oCutYR2TZFzoc4iCSxZ5UAHtSYFirz2Uq5GLfS6EWD25MbYXWrbv/qBXHUAwWPF23izvrQ=="
+      "version": "9.0.0-rc.32",
+      "resolved": "https://registry.npmjs.org/@directus/schema/-/schema-9.0.0-rc.32.tgz",
+      "integrity": "sha512-cDfPEfA+7HC1iidLLyV992zWllhfP249Y2wvgFG+Ljzy58HcY3ZWW1xvyABmpIC9iuNnTvwVdtQPyYX+NEYEjQ=="
     },
     "@directus/specs": {
-      "version": "9.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/@directus/specs/-/specs-9.0.0-rc.20.tgz",
-      "integrity": "sha512-w5inHHr6MTnlwBzLLgkDs8cFeyH+ZsKClqCGpHz3NZZUrSyqvYeVgCrPIygRMPRCDZuiKAKgH7KUw4S0eD78Lw=="
+      "version": "9.0.0-rc.32",
+      "resolved": "https://registry.npmjs.org/@directus/specs/-/specs-9.0.0-rc.32.tgz",
+      "integrity": "sha512-x0lnrhknGM2Vcd9KRxXm++T+CFR40NyGhPjyIT6xdMVjk9xjdkRt/sDAVEgnm/kCxjxcfGWiXj/7FMzUUoUqhQ=="
     },
     "@godaddy/terminus": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.4.1.tgz",
-      "integrity": "sha512-ZPwsG7xN+B2bvnEu6+o0rBPAFbXmm6Bk/RAR4b/nhjNOSJtbVFYTd+JSaJYL/jyESqcTcAyzlWO0dmbT4YsckQ==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@godaddy/terminus/-/terminus-4.6.0.tgz",
+      "integrity": "sha512-5OaPBRYIex8YcvK+Jk6/wUNulaQMWt1RWIpfYmRbP+1On5FRf3bumDWBni3V0RQRkm3JIvZiXbIndumEtasOMg==",
       "requires": {
-        "es6-promisify": "^6.0.2",
         "stoppable": "^1.1.0"
       }
     },
@@ -143,16 +112,17 @@
       "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
     },
     "@google-cloud/storage": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.6.0.tgz",
-      "integrity": "sha512-nLcym8IuCzy1O7tNTXNFuMHfX900sTM3kSTqbKe7oFSoKUiaIM+FHuuuDimMMlieY6StA1xYNPRFFHz57Nv8YQ==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.7.3.tgz",
+      "integrity": "sha512-1or09kfx8bmSMG5MvTCiuooCfS0btDtchvwQpIx/iF2IogzmFhLFFtmCeEpstTsfql6bHAnvN8Up7W5+9kMgdA==",
       "requires": {
         "@google-cloud/common": "^3.5.0",
         "@google-cloud/paginator": "^3.0.0",
         "@google-cloud/promisify": "^2.0.0",
         "arrify": "^2.0.0",
+        "async-retry": "^1.3.1",
         "compressible": "^2.0.12",
-        "date-and-time": "^0.14.0",
+        "date-and-time": "^0.14.2",
         "duplexify": "^4.0.0",
         "extend": "^3.0.2",
         "gaxios": "^4.0.0",
@@ -170,9 +140,9 @@
       }
     },
     "@hapi/hoek": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.0.tgz",
-      "integrity": "sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw=="
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.1.1.tgz",
+      "integrity": "sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw=="
     },
     "@hapi/topo": {
       "version": "5.0.0",
@@ -306,9 +276,9 @@
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
     "@types/node": {
-      "version": "12.19.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.8.tgz",
-      "integrity": "sha512-D4k2kNi0URNBxIRCb1khTnkWNHv8KSL1owPmS/K5e5t8B2GzMReY7AsJIY1BnP5KdlgC4rj9jk2IkDMasIE7xg==",
+      "version": "12.19.15",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
+      "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw==",
       "optional": true
     },
     "@types/readable-stream": {
@@ -489,13 +459,13 @@
       }
     },
     "argon2": {
-      "version": "0.27.0",
-      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.27.0.tgz",
-      "integrity": "sha512-IkhJhz/4qaZ6RpYyRZvAMOu+EysF40z3J8jksvv0V9LvQFo13d2WBQr5lPuMzZid2k5XpdbQd2oVsgXR4Oi8TQ==",
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/argon2/-/argon2-0.27.1.tgz",
+      "integrity": "sha512-On68kSinTh4DOlLVCEYgQYpx0yuGRsqU9UwV7jUB26PWv+092r8Uz891KFVEqdsksiDXDhA7kXL4z3in/FBItg==",
       "requires": {
         "@phc/format": "^1.0.0",
-        "node-addon-api": "^3.0.0",
-        "node-pre-gyp": "^0.15.0",
+        "node-addon-api": "^3.0.2",
+        "node-pre-gyp": "^0.17.0",
         "opencollective-postinstall": "^2.0.3"
       }
     },
@@ -506,12 +476,6 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "argv": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
-      "optional": true
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -591,6 +555,14 @@
       "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
       "optional": true
     },
+    "async-retry": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.1.tgz",
+      "integrity": "sha512-aiieFW/7h3hY0Bq5d+ktDBejxuwR78vRu9hDUdR8rNhSaQ29VzPL4AoIRG7D/c7tdenwOcKvgPM6tIxB3cB6HA==",
+      "requires": {
+        "retry": "0.12.0"
+      }
+    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -613,9 +585,9 @@
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "aws-sdk": {
-      "version": "2.804.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.804.0.tgz",
-      "integrity": "sha512-a02pZdjL06MunElAZPPEjpghOp/ZA+16f+t4imh1k9FCDpsNVQrT23HRq/PMvRADA5uZZRkYwX8r9o6oH/1RlA==",
+      "version": "2.831.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.831.0.tgz",
+      "integrity": "sha512-lrOjbGFpjk2xpESyUx2PGsTZgptCy5xycZazPeakNbFO19cOoxjHx3xyxOHsMCYb3pQwns35UvChQT60B4u6cw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -648,9 +620,9 @@
       "optional": true
     },
     "axios": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
-      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
       "requires": {
         "follow-redirects": "^1.10.0"
       }
@@ -966,56 +938,6 @@
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
-    "codecov": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.8.1.tgz",
-      "integrity": "sha512-Qm7ltx1pzLPsliZY81jyaQ80dcNR4/JpcX0IHCIWrHBXgseySqbdbYfkdiXd7o/xmzQpGRVCKGYeTrHUpn6Dcw==",
-      "optional": true,
-      "requires": {
-        "argv": "0.0.2",
-        "ignore-walk": "3.0.3",
-        "js-yaml": "3.14.0",
-        "teeny-request": "6.0.1",
-        "urlgrey": "0.4.4"
-      },
-      "dependencies": {
-        "agent-base": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-          "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-          "optional": true
-        },
-        "https-proxy-agent": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
-          "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-          "optional": true,
-          "requires": {
-            "agent-base": "5",
-            "debug": "4"
-          }
-        },
-        "teeny-request": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-6.0.1.tgz",
-          "integrity": "sha512-TAK0c9a00ELOqLrZ49cFxvPVogMUFaWY8dUsQc/0CuQPGF+BOxOQzXfE413BAk2kLomwNplvdtMpeaeGWmoc2g==",
-          "optional": true,
-          "requires": {
-            "http-proxy-agent": "^4.0.0",
-            "https-proxy-agent": "^4.0.0",
-            "node-fetch": "^2.2.0",
-            "stream-events": "^1.0.5",
-            "uuid": "^3.3.2"
-          }
-        },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-          "optional": true
-        }
-      }
-    },
     "collection-visit": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1086,9 +1008,9 @@
       }
     },
     "commander": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
     },
     "component-emitter": {
       "version": "1.3.0",
@@ -1215,9 +1137,9 @@
       }
     },
     "date-and-time": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.14.1.tgz",
-      "integrity": "sha512-M4RggEH5OF2ZuCOxgOU67R6Z9ohjKbxGvAQz48vj53wLmL0bAgumkBvycR32f30pK+Og9pIR+RFDyChbaE4oLA=="
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.14.2.tgz",
+      "integrity": "sha512-EFTCh9zRSEpGPmJaexg7HTuzZHh6cnJj1ui7IGCFNXzd2QdpsNh05Db5TF3xzJm30YN+A8/6xHSuRcQqoc3kFA=="
     },
     "date-fns": {
       "version": "2.16.1",
@@ -1236,6 +1158,13 @@
       "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
       "requires": {
         "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "decode-uri-component": {
@@ -1322,9 +1251,9 @@
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
     },
     "denque": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-      "integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
+      "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ==",
       "optional": true
     },
     "depd": {
@@ -1356,14 +1285,14 @@
       }
     },
     "directus": {
-      "version": "9.0.0-rc.20",
-      "resolved": "https://registry.npmjs.org/directus/-/directus-9.0.0-rc.20.tgz",
-      "integrity": "sha512-xtxKcxD/Hq8oPYxblftlnY8rlZ0DoXQgDxnWbRAEaIlkbk8UahkTpJTnuQaORJGJldaBGqUabQYdo/7uwN2BYA==",
+      "version": "9.0.0-rc.32",
+      "resolved": "https://registry.npmjs.org/directus/-/directus-9.0.0-rc.32.tgz",
+      "integrity": "sha512-vej0MJYWFrCVgP3c9w83BrOxaQ6g3W4g1PLr2FtFh5mJXO2PvRXyac+DdwjVSXX0KcTv8t1bzmaJLjmHm2NeNQ==",
       "requires": {
-        "@directus/app": "^9.0.0-rc.20",
-        "@directus/format-title": "^9.0.0-rc.20",
-        "@directus/schema": "^9.0.0-rc.20",
-        "@directus/specs": "^9.0.0-rc.20",
+        "@directus/app": "^9.0.0-rc.32",
+        "@directus/format-title": "^9.0.0-rc.32",
+        "@directus/schema": "^9.0.0-rc.32",
+        "@directus/specs": "^9.0.0-rc.32",
         "@godaddy/terminus": "^4.4.1",
         "@keyv/redis": "^2.1.2",
         "@slynova/flydrive": "^1.0.3",
@@ -1386,7 +1315,6 @@
         "execa": "^4.1.0",
         "exif-reader": "^1.0.3",
         "express": "^4.17.1",
-        "express-async-handler": "^1.1.4",
         "express-graphql": "^0.11.0",
         "express-pino-logger": "^5.0.0",
         "express-session": "^1.17.1",
@@ -1426,7 +1354,7 @@
         "rate-limiter-flexible": "^2.1.13",
         "resolve-cwd": "^3.0.0",
         "sharp": "^0.26.2",
-        "sqlite3": "^5.0.0",
+        "sqlite3": "5.0.0",
         "uuid": "^8.3.1",
         "uuid-validate": "0.0.3"
       }
@@ -1515,11 +1443,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
       "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
-    },
-    "es6-promisify": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-6.1.1.tgz",
-      "integrity": "sha512-HBL8I3mIki5C1Cc9QjKUenHtnG0A5/xA8Q/AllRcfiwl2CZFXGK7ddBiCoRwAix4i2KxcQfjtIVcrVbB3vbmwg=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1711,11 +1634,6 @@
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
-    },
-    "express-async-handler": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/express-async-handler/-/express-async-handler-1.1.4.tgz",
-      "integrity": "sha512-HdmbVF4V4w1q/iz++RV7bUxIeepTukWewiJGkoCKQMtvPF11MLTa7It9PRc/reysXXZSEyD4Pthchju+IUbMiQ=="
     },
     "express-graphql": {
       "version": "0.11.0",
@@ -2056,9 +1974,9 @@
       "integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.2.tgz",
+      "integrity": "sha512-6mPTgLxYm3r6Bkkg0vNM0HTjfGrOEtsfbhagQvbxDEsEkpNhw582upBaoRZylzen6krEmxXJgt9Ju6HiI4O7BA=="
     },
     "for-in": {
       "version": "1.0.2",
@@ -2114,14 +2032,14 @@
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
     },
     "fs-extra": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
-      "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "requires": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
-        "universalify": "^1.0.0"
+        "universalify": "^2.0.0"
       }
     },
     "fs-minipass": {
@@ -2170,9 +2088,9 @@
       }
     },
     "gaxios": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
-      "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
+      "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
@@ -2191,31 +2109,17 @@
       }
     },
     "gcs-resumable-upload": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.1.tgz",
-      "integrity": "sha512-RS1osvAicj9+MjCc6jAcVL1Pt3tg7NK2C2gXM5nqD1Gs0klF2kj5nnAFSBy97JrtslMIQzpb7iSuxaG8rFWd2A==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.2.tgz",
+      "integrity": "sha512-VKWP3Xju1JmNX3N4ossnGp3DfIRZjOsMj8sDGPBGnvn8YSruCOVGQBvELfStfIFPybScv/e5sEdWx/qzfnS3+w==",
       "requires": {
         "abort-controller": "^3.0.0",
         "configstore": "^5.0.0",
         "extend": "^3.0.2",
-        "gaxios": "^3.0.0",
+        "gaxios": "^4.0.0",
         "google-auth-library": "^6.0.0",
         "pumpify": "^2.0.0",
         "stream-events": "^1.0.4"
-      },
-      "dependencies": {
-        "gaxios": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.2.0.tgz",
-          "integrity": "sha512-+6WPeVzPvOshftpxJwRi2Ozez80tn/hdtOUag7+gajDHRJvAblKxTFSSMPtr2hmnLy7p0mvYz0rMXLBl8pSO7Q==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "extend": "^3.0.2",
-            "https-proxy-agent": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "node-fetch": "^2.3.0"
-          }
-        }
       }
     },
     "get-stream": {
@@ -2293,9 +2197,9 @@
       }
     },
     "google-auth-library": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
-      "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.5.tgz",
+      "integrity": "sha512-vlizrMSlHIu6blPtSC9AJZ1xYQWqUp1xqhcMzYff+hNKTSqVlsynMQIE8BdCo/FhPib4U1fvv1gnczMDHB2Wmg==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -2360,9 +2264,9 @@
       "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
     },
     "gtoken": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
-      "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.0.tgz",
+      "integrity": "sha512-qbf6JWEYFMj3WMAluvYXl8GAiji6w8d9OmAGCbBg0xF4xD/yu6ZaO6BhoXNddRjKcOUpZD81iea1H5B45gAo1g==",
       "requires": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
@@ -2577,9 +2481,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inquirer": {
       "version": "7.3.3",
@@ -2637,9 +2541,9 @@
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
     },
     "ioredis": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.19.2.tgz",
-      "integrity": "sha512-SZSIwMrbd96b7rJvJwyTWSP6XQ0m1kAIIqBnwglJKrIJ6na7TeY4F2EV2vDY0xm/fLrUY8cEg81dR7kVFt2sKA==",
+      "version": "4.19.4",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.19.4.tgz",
+      "integrity": "sha512-3haQWw9dpEjcfVcRktXlayVNrrqvvc2io7Q/uiV2UsYw8/HC2YwwJr78Wql7zu5bzwci0x9bZYA69U7KkevAvw==",
       "optional": true,
       "requires": {
         "cluster-key-slot": "^1.1.0",
@@ -2868,6 +2772,14 @@
       "optional": true,
       "requires": {
         "retry": "0.6.0"
+      },
+      "dependencies": {
+        "retry": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
+          "integrity": "sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc=",
+          "optional": true
+        }
       }
     },
     "jmespath": {
@@ -2888,9 +2800,9 @@
       }
     },
     "js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2956,13 +2868,6 @@
       "requires": {
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
-      },
-      "dependencies": {
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-        }
       }
     },
     "jsonparse": {
@@ -3064,12 +2969,11 @@
       }
     },
     "keyv-memcache": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/keyv-memcache/-/keyv-memcache-1.0.1.tgz",
-      "integrity": "sha512-QYU4UQkVFmZdtDizMi7mGv52mK/WOyuz4/W1X/L3W7pv21/PCoFUH5lsqmUMAM7dODx7LeIy7sH4dDz16w5bcQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/keyv-memcache/-/keyv-memcache-1.0.2.tgz",
+      "integrity": "sha512-nTmRUArJKOF0TEba5S16EXgTVWxdQEUA0ld2TYEtuZIG3JPEsI9p7h2lHBwlMEocVRFG4r9v7ozG8rQ92VUIyg==",
       "optional": true,
       "requires": {
-        "codecov": "^3.6.5",
         "json-buffer": "^3.0.1",
         "memjs": "^1.2.2"
       }
@@ -3080,37 +2984,22 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "knex": {
-      "version": "0.21.12",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.21.12.tgz",
-      "integrity": "sha512-AEyyiTM9p/x/Pb38TPZkvphKPmn8UWxP7MdIphzjAOielOfFFeU6pjP6y3M7UJ7rxrQsCrAYHwdonLQ3l1JCDw==",
+      "version": "0.21.16",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.21.16.tgz",
+      "integrity": "sha512-M3FTFfby49AEngsx/0UXEJEMnKMjPjeKOtvk+AY6d6kboz9NsT7xDudl0wRNj+S0lq0yearCSb1v+YxgbU/kWA==",
       "requires": {
         "colorette": "1.2.1",
-        "commander": "^5.1.0",
-        "debug": "4.1.1",
+        "commander": "^6.2.0",
+        "debug": "4.3.1",
         "esm": "^3.2.25",
         "getopts": "2.2.5",
         "interpret": "^2.2.0",
         "liftoff": "3.1.0",
         "lodash": "^4.17.20",
-        "pg-connection-string": "2.3.0",
+        "pg-connection-string": "2.4.0",
         "tarn": "^3.0.1",
         "tildify": "2.0.0",
         "v8flags": "^3.2.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
       }
     },
     "liftoff": {
@@ -3129,9 +3018,9 @@
       }
     },
     "liquidjs": {
-      "version": "9.16.1",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.16.1.tgz",
-      "integrity": "sha512-bo/EpbQ5u3ZIMtk4NT56wWlWi/ZQz0E/x5GB81BmrbU5Txa7Z2Ha08XYZGXTGXlW0wTWwIgDVk//oxMm35Vugw=="
+      "version": "9.20.1",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.20.1.tgz",
+      "integrity": "sha512-pXXraZ6wKhSuTwLVtoQ9iOgayeKhR6J9PP9IqELGox2BbJ2MlQkDPO1HNCWZDHDVFbddtnb5ZIhxCFUjkZQ10w=="
     },
     "lodash": {
       "version": "4.17.20",
@@ -3256,9 +3145,9 @@
       }
     },
     "memjs": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/memjs/-/memjs-1.2.2.tgz",
-      "integrity": "sha512-j6I5cQsjT8izm0FcBZrwga4VmlhTMsBTPKdyKolQenLulHNvKuNcDgDmBhQvScqNLy4tjpCCFwiqFK+5l6J20g==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/memjs/-/memjs-1.3.0.tgz",
+      "integrity": "sha512-y/V9a0auepA9Lgyr4QieK6K2FczjHucEdTpSS+hHVNmVEkYxruXhkHu8n6DSRQ4HXHEE3cc6Sf9f88WCJXGXsQ==",
       "optional": true
     },
     "merge-descriptors": {
@@ -3297,9 +3186,9 @@
       }
     },
     "mime": {
-      "version": "2.4.6",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
+      "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag=="
     },
     "mime-db": {
       "version": "1.45.0",
@@ -3307,18 +3196,11 @@
       "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
     },
     "mime-types": {
-      "version": "2.1.27",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
-      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+      "version": "2.1.28",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
+      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
       "requires": {
-        "mime-db": "1.44.0"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.44.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
-          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
-        }
+        "mime-db": "1.45.0"
       }
     },
     "mimic-fn": {
@@ -3413,19 +3295,19 @@
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
     "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "mssql": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/mssql/-/mssql-6.2.3.tgz",
-      "integrity": "sha512-4TW/fA9UgzmVTNgjl65r6ISr6aL5QHnlptEt1A3jIpdzkNbFPIkRbUNz90324HIdE+5pKc3VqikOImcTrhd4og==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/mssql/-/mssql-6.3.1.tgz",
+      "integrity": "sha512-ammxrhbdDpcBWhiZLiy6miiU7ELt9qFbGvwmPbiufn+tBHAYUFR/AgwE4/v4jzPzbatowscmhFx1U61L91uVzQ==",
       "optional": true,
       "requires": {
-        "debug": "^4",
+        "debug": "^4.3.1",
         "tarn": "^1.1.5",
-        "tedious": "^6.6.2"
+        "tedious": "^6.7.0"
       },
       "dependencies": {
         "tarn": {
@@ -3526,9 +3408,9 @@
       "optional": true
     },
     "needle": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
-      "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-2.6.0.tgz",
+      "integrity": "sha512-KKYdza4heMsEfSWD7VPUIz3zX2XDwOyX2d+geb4vrERZMT5RMU6ujjaD+I5Yr54uZxQ2w6XRTAhHBbSCyovZBg==",
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -3571,9 +3453,9 @@
       }
     },
     "node-addon-api": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
-      "integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.1.0.tgz",
+      "integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw=="
     },
     "node-exceptions": {
       "version": "4.0.1",
@@ -3653,20 +3535,20 @@
       "integrity": "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="
     },
     "node-pre-gyp": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
-      "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.17.0.tgz",
+      "integrity": "sha512-abzZt1hmOjkZez29ppg+5gGqdPLUuJeAEwVPtHYEJgx0qzttCbcKFpxrCQn2HYbwCv2c+7JwH4BgEzFkUGpn4A==",
       "requires": {
-        "detect-libc": "^1.0.2",
-        "mkdirp": "^0.5.3",
-        "needle": "^2.5.0",
-        "nopt": "^4.0.1",
-        "npm-packlist": "^1.1.6",
-        "npmlog": "^4.0.2",
-        "rc": "^1.2.7",
-        "rimraf": "^2.6.1",
-        "semver": "^5.3.0",
-        "tar": "^4.4.2"
+        "detect-libc": "^1.0.3",
+        "mkdirp": "^0.5.5",
+        "needle": "^2.5.2",
+        "nopt": "^4.0.3",
+        "npm-packlist": "^1.4.8",
+        "npmlog": "^4.1.2",
+        "rc": "^1.2.8",
+        "rimraf": "^2.7.1",
+        "semver": "^5.7.1",
+        "tar": "^4.4.13"
       },
       "dependencies": {
         "semver": {
@@ -3677,9 +3559,9 @@
       }
     },
     "nodemailer": {
-      "version": "6.4.16",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.16.tgz",
-      "integrity": "sha512-68K0LgZ6hmZ7PVmwL78gzNdjpj5viqBdFqKrTtr9bZbJYj6BRj5W6WGkxXrEnUl3Co3CBXi3CZBUlpV/foGnOQ=="
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-89ps+SBGpo0D4Bi5ZrxcrCiRFaMmkCt+gItMXQGzEtZVR3uAD3QAQIDoxTWnx3ky0Dwwy/dhFrQ+6NNGXpw/qQ=="
     },
     "noop-logger": {
       "version": "0.1.1",
@@ -3846,9 +3728,9 @@
       }
     },
     "openapi3-ts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.0.tgz",
-      "integrity": "sha512-q4p8OX/mD7qXeDKkhdLhpEz1Zh/IxPBDWmuq7f07fQJpo7exUW20sMrHfws1xzihYPktTXVV5MDOZkG/1uguEg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-2.0.1.tgz",
+      "integrity": "sha512-v6X3iwddhi276siej96jHGIqTx3wzVfMTmpGJEQDt7GPI7pI6sywItURLzpEci21SBRpPN/aOWSF5mVfFVNmcg==",
       "requires": {
         "yaml": "^1.10.0"
       }
@@ -3859,16 +3741,16 @@
       "integrity": "sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q=="
     },
     "ora": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-5.1.0.tgz",
-      "integrity": "sha512-9tXIMPvjZ7hPTbk8DFq1f7Kow/HU/pQYB60JbNq+QnGwcyhWVZaQ4hM9zQDEsPxw/muLpgiHSaumUZxCAmod/w==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.3.0.tgz",
+      "integrity": "sha512-zAKMgGXUim0Jyd6CXK9lraBnD3H5yPGBPPOkC23a2BG6hsm4Zu6OQSjQuEtV0BHDf4aKHcUFvJiGRrFuW3MG8g==",
       "requires": {
+        "bl": "^4.0.3",
         "chalk": "^4.1.0",
         "cli-cursor": "^3.1.0",
-        "cli-spinners": "^2.4.0",
+        "cli-spinners": "^2.5.0",
         "is-interactive": "^1.0.0",
         "log-symbols": "^4.0.0",
-        "mute-stream": "0.0.8",
         "strip-ansi": "^6.0.0",
         "wcwidth": "^1.0.1"
       },
@@ -3877,6 +3759,25 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+        },
+        "bl": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+          "requires": {
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "buffer": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+          "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.1.13"
+          }
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -3889,9 +3790,9 @@
       }
     },
     "oracledb": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-5.0.0.tgz",
-      "integrity": "sha512-NLE3t6KiAkpBHA1/zgjNiKaa9Z4Nnp4PuB3d0b3Kz4C8klrIrMKfHIGUySlwqgDW588m7/2hnPxU7PH6wjBd6g==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-5.1.0.tgz",
+      "integrity": "sha512-/IpzG729lFj8NBsA0xaOijdf6ZO3VuJbebma/hSf+VUZoIyzI/mCzBX047ramb/W8yJ1SV/HdWgs+XEczbqsXg==",
       "optional": true
     },
     "os-homedir": {
@@ -4049,9 +3950,9 @@
       }
     },
     "pg-connection-string": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.3.0.tgz",
-      "integrity": "sha512-ukMTJXLI7/hZIwTW7hGMZJ0Lj0S2XQBCJ4Shv4y1zgQ/vqVea+FLhzywvPj0ujSuofu+yA4MYHGZPTsgjBgJ+w=="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.4.0.tgz",
+      "integrity": "sha512-3iBXuv7XKvxeMrIgym7njT+HlZkwZqqGX4Bu9cci8xHZNT+Um1gWKqCsAzcC0d95rcKMU5WBg6YRUcHyV0HZKQ=="
     },
     "pg-int8": {
       "version": "1.0.1",
@@ -4089,16 +3990,23 @@
       }
     },
     "pino": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.7.0.tgz",
-      "integrity": "sha512-vPXJ4P9rWCwzlTJt+f0Ni4THc3DWyt8iDDCO4edQ8narTu6hnpzdXu8FqeSJCGndl1W6lfbYQUQihUO54y66Lw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.0.tgz",
+      "integrity": "sha512-VPqEE2sU1z6wqkTtr7DdTktayTNE/JgeuWjfXh9g/TI6X7venzv4gaoU24/jSywf6bBeDfZRHWEeO/6f8bNppA==",
       "requires": {
         "fast-redact": "^3.0.0",
         "fast-safe-stringify": "^2.0.7",
         "flatstr": "^1.0.12",
-        "pino-std-serializers": "^2.4.2",
+        "pino-std-serializers": "^3.1.0",
         "quick-format-unescaped": "^4.0.1",
         "sonic-boom": "^1.0.2"
+      },
+      "dependencies": {
+        "pino-std-serializers": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+          "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+        }
       }
     },
     "pino-colada": {
@@ -4261,9 +4169,9 @@
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
     },
     "qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -4286,9 +4194,9 @@
       "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="
     },
     "rate-limiter-flexible": {
-      "version": "2.1.13",
-      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.1.13.tgz",
-      "integrity": "sha512-EDzvV/ee/rCBKNL5Jw0Rr0rjneT/L4zLGgVS9xB6ShfVMkV5iviWKr+2tjzgBg5kd9by5F08C9DfXfH6v/kz3w=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.2.1.tgz",
+      "integrity": "sha512-rxCP6kDDdn0cZmVqVlF06yLU+mG3TuwaHV/fUIw3OQyYhza7pzVBtdMhUmfXbBzMS+O464XP+x33pfTDGRGYVA=="
     },
     "raw-body": {
       "version": "2.4.0",
@@ -4429,20 +4337,13 @@
       "integrity": "sha512-mIWvU9HA2whb/fHcqeQ0LQXAImCGISqUPyjuFF2rALhym2Fu4ebZGv7wxFA78rsJO/fn2OeEaK54TSjwSwRAFw=="
     },
     "request-oauth": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/request-oauth/-/request-oauth-1.0.0.tgz",
-      "integrity": "sha512-wsDzIq1Qu2itLDlcpFph8xh5Q+FVyUj4os5zdQTlZL/JvZYF/qOyaawVPsxxhDG4QwCB3tzSFprj6dkjqR+e8w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/request-oauth/-/request-oauth-1.0.1.tgz",
+      "integrity": "sha512-85THTg1RgOYtqQw42JON6AqvHLptlj1biw265Tsq4fD4cPdUvhDB2Qh9NTv17yCD322ROuO9aOmpc4GyayGVBA==",
       "requires": {
         "oauth-sign": "^0.9.0",
-        "qs": "^6.9.3",
-        "uuid": "^3.4.0"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
-        }
+        "qs": "^6.9.6",
+        "uuid": "^8.3.2"
       }
     },
     "resolve": {
@@ -4496,10 +4397,9 @@
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "retry": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz",
-      "integrity": "sha1-HAEHEyeab9Ho3vKK8MP/GHHKpTc=",
-      "optional": true
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
     "retry-request": {
       "version": "4.1.3",
@@ -5109,9 +5009,9 @@
       }
     },
     "tar-stream": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.4.tgz",
-      "integrity": "sha512-o3pS2zlG4gxr67GmFYBLlq+dM8gyRGUOvsrHclSkvtVtQbjV0s/+ZE8OpICbaj8clrX3tjeHngYGP7rweaBnuw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "requires": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -5376,9 +5276,9 @@
       }
     },
     "universalify": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
-      "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug=="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -5422,9 +5322,9 @@
       }
     },
     "uri-js": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
-      "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "optional": true,
       "requires": {
         "punycode": "^2.1.0"
@@ -5452,12 +5352,6 @@
         "querystring": "0.2.0"
       }
     },
-    "urlgrey": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
-      "optional": true
-    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
@@ -5474,9 +5368,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
-      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "uuid-validate": {
       "version": "0.0.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "directus": "^9.0.0-rc.20",
+    "directus": "^9.0.0-rc.31",
     "pg": "^8.5.1"
   }
 }


### PR DESCRIPTION
- Dependency updates
- `extensions` added to mounts
- mounts juggle cleaned up for local `uploads` and `extensions` dev
- Updated `.environment` file to avoid `.env` copying
- Adds Redis and Memcached support
- Email support: related to https://github.com/directus/directus/issues/3703#issuecomment-761075873
     - Email env variables
     - Trailing slash removed from `PUBLIC_URL` (screwed up password reset link)
     - README updated to make initial admin user/pw clear
     - Required downgrade to Node 12