### PR TITLE
Updated Directus and added new bootstrap commands

### DIFF
--- a/.environment
+++ b/.environment
@@ -127,5 +127,5 @@ export EMAIL_SMTP_PORT=25
 export PROJECT_NAME='Directus on Platform.sh'
 
 # Initial admin user on first deploy.
-export INIT_ADMINUSER='admin@example.com'
-export INIT_ADMINPW='password'
+export ADMIN_EMAIL='admin@example.com'
+export ADMIN_PASSWORD='password'

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -32,23 +32,10 @@ hooks:
         fi
     deploy: |
         set -e
-        # Installs the database and sets up the initial admin user. Only run on first deploy.
-        if [ ! -f var/platformsh.installed ]; then
-            # Install the database
-            echo 'Installing the database...'
-            npx directus database install
 
-            # Create the admin user role
-            echo 'Setting up the initial admin role...'
-            ROLE_UUID=$(npx directus roles create --name admin --admin)
+        # Installs the database and sets up the initial admin user if needed. Otherwise just run migrations.
+        npx directus bootstrap
 
-            # Pipe output of above command into this one, adding an initial admin user
-            echo 'Creating the initial admin user...'
-            npx directus users create --email $INIT_ADMINUSER --password $INIT_ADMINPW --role $ROLE_UUID
-
-            # Create file that indicates first deploy and installation has been completed.
-            touch var/platformsh.installed
-        fi;
         # Copy committed extensions and uploads back onto writable mounts.
         if [ -d extensions-tmp ]
         then
@@ -59,22 +46,22 @@ hooks:
             cp -r uploads-tmp/* uploads
         fi
 
-# Start the Directus server. 
+# Start the Directus server.
 web:
     commands:
-        start: npx directus start    
+        start: npx directus start
 
 # The size of the persistent disk of the application (in MB).
 disk: 1024
 
 # Platform.sh write access at runtime.
 mounts:
-    'extensions':
+    "extensions":
         source: local
         source_path: extensions
-    'uploads':
+    "uploads":
         source: local
         source_path: uploads
-    'var':
+    "var":
         source: local
         source_path: var

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ This template does not require any additional configuration once deployed to sta
 
 ```txt
 # Initial admin user on first deploy.
-export INIT_ADMINUSER='admin@example.com'
-export INIT_ADMINPW='password'
+export ADMIN_EMAIL='admin@example.com'
+export ADMIN_PASSWORD='password'
 ```
 
 After you log in for the first time, be sure to update this password immediately. 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,87 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/abort-controller": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.2.tgz",
+      "integrity": "sha512-XUyTo+bcyxHEf+jlN2MXA7YU9nxVehaubngHV1MIZZaqYmZqykkoeAz/JMMEeR7t3TcyDwbFa3Zw8BZywmIx4g==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
+    "@azure/core-asynciterator-polyfill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-asynciterator-polyfill/-/core-asynciterator-polyfill-1.0.0.tgz",
+      "integrity": "sha512-kmv8CGrPfN9SwMwrkiBK9VTQYxdFQEGe0BmQk+M8io56P9KNzpAxcWE/1fxJj7uouwN4kXF0BHW8DNlgx+wtCg=="
+    },
+    "@azure/core-auth": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.2.0.tgz",
+      "integrity": "sha512-KUl+Nwn/Sm6Lw5d3U90m1jZfNSL087SPcqHLxwn2T6PupNKmcgsEbDjHB25gDvHO4h7pBsTlrdJAY7dz+Qk8GA==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@azure/core-http": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-http/-/core-http-1.2.3.tgz",
+      "integrity": "sha512-g5C1zUJO5dehP2Riv+vy9iCYoS1UwKnZsBVCzanScz9A83LbnXKpZDa9wie26G9dfXUhQoFZoFT8LYWhPKmwcg==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-auth": "^1.1.3",
+        "@azure/core-tracing": "1.0.0-preview.9",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.10.2",
+        "@types/node-fetch": "^2.5.0",
+        "@types/tunnel": "^0.0.1",
+        "form-data": "^3.0.0",
+        "node-fetch": "^2.6.0",
+        "process": "^0.11.10",
+        "tough-cookie": "^4.0.0",
+        "tslib": "^2.0.0",
+        "tunnel": "^0.0.6",
+        "uuid": "^8.3.0",
+        "xml2js": "^0.4.19"
+      }
+    },
+    "@azure/core-lro": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-lro/-/core-lro-1.0.3.tgz",
+      "integrity": "sha512-Py2crJ84qx1rXkzIwfKw5Ni4WJuzVU7KAF6i1yP3ce8fbynUeu8eEWS4JGtSQgU7xv02G55iPDROifmSDbxeHA==",
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.2.0",
+        "events": "^3.0.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@azure/core-paging": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.1.3.tgz",
+      "integrity": "sha512-his7Ah40ThEYORSpIAwuh6B8wkGwO/zG7gqVtmSE4WAJ46e36zUDXTKReUCLBDc6HmjjApQQxxcRFy5FruG79A==",
+      "requires": {
+        "@azure/core-asynciterator-polyfill": "^1.0.0"
+      }
+    },
+    "@azure/core-tracing": {
+      "version": "1.0.0-preview.9",
+      "resolved": "https://registry.npmjs.org/@azure/core-tracing/-/core-tracing-1.0.0-preview.9.tgz",
+      "integrity": "sha512-zczolCLJ5QG42AEPQ+Qg9SRYNUyB+yZ5dzof4YEc+dyWczO9G2sBqbAjLB7IqrsdHN2apkiB2oXeDKCsq48jug==",
+      "requires": {
+        "@opencensus/web-types": "0.0.7",
+        "@opentelemetry/api": "^0.10.2",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@azure/logger": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@azure/logger/-/logger-1.0.1.tgz",
+      "integrity": "sha512-QYQeaJ+A5x6aMNu8BG5qdsVBnYBop9UMwgUvGihSjf1PdZZXB+c/oMdM2ajKwzobLBh9e9QuMQkN9iL+IxLBLA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "@azure/ms-rest-azure-env": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-1.1.2.tgz",
@@ -11,12 +92,12 @@
       "optional": true
     },
     "@azure/ms-rest-js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.9.1.tgz",
-      "integrity": "sha512-F1crHKhmsvFLM9fsnDyCGFd2E2KR9GEZm5oBVV5D5k2EBQ7u7idtSJlSF6RDLDIrGWtc4NnFdYwsoiW8NLlBQg==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.11.2.tgz",
+      "integrity": "sha512-2AyQ1IKmLGKW7DU3/x3TsTBzZLcbC9YRI+yuDPuXAQrv3zar340K9wsxU413kHFIDjkWNCo9T0w5VtwcyWxhbQ==",
       "optional": true,
       "requires": {
-        "@types/tunnel": "0.0.0",
+        "@azure/core-auth": "^1.1.4",
         "axios": "^0.21.1",
         "form-data": "^2.3.2",
         "tough-cookie": "^2.4.3",
@@ -26,6 +107,33 @@
         "xml2js": "^0.4.19"
       },
       "dependencies": {
+        "form-data": {
+          "version": "2.5.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
+          "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
+          "optional": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.6",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "optional": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -45,28 +153,83 @@
         "adal-node": "^0.1.28"
       }
     },
-    "@directus/app": {
-      "version": "9.0.0-rc.32",
-      "resolved": "https://registry.npmjs.org/@directus/app/-/app-9.0.0-rc.32.tgz",
-      "integrity": "sha512-oMc6sLXwxFzRoJqWiPx8rLMkLLh5sRNcIENAzZO8s6kVjlZ627i9qJXRWqJRgVgNkJXPZeFBsb6eo7Y6wnc4Bw==",
+    "@azure/storage-blob": {
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/@azure/storage-blob/-/storage-blob-12.4.1.tgz",
+      "integrity": "sha512-RH6ru8LbnCC+m1rlVLon6mYUXdHsTcyUXFCJAWRQQM7p0XOwVKPS+UiVk2tZXfvMWd3q/qT/meOrEbHEcp/c4g==",
       "requires": {
-        "@directus/format-title": "^9.0.0-rc.32"
+        "@azure/abort-controller": "^1.0.0",
+        "@azure/core-http": "^1.2.0",
+        "@azure/core-lro": "^1.0.2",
+        "@azure/core-paging": "^1.1.1",
+        "@azure/core-tracing": "1.0.0-preview.9",
+        "@azure/logger": "^1.0.0",
+        "@opentelemetry/api": "^0.10.2",
+        "events": "^3.0.0",
+        "tslib": "^2.0.0"
+      }
+    },
+    "@directus/app": {
+      "version": "9.0.0-rc.40",
+      "resolved": "https://registry.npmjs.org/@directus/app/-/app-9.0.0-rc.40.tgz",
+      "integrity": "sha512-ijvYfw5Rxsdixpy1vO7zkn2y6nqcf1sNJMnjfC5xsFug4B3pj8xxDue9ea9350LRrkXg9m9V03M0KZDgk8P3lg==",
+      "requires": {
+        "@directus/docs": "^9.0.0-rc.40",
+        "@directus/format-title": "^9.0.0-rc.40"
+      }
+    },
+    "@directus/docs": {
+      "version": "9.0.0-rc.40",
+      "resolved": "https://registry.npmjs.org/@directus/docs/-/docs-9.0.0-rc.40.tgz",
+      "integrity": "sha512-va3x8W1coSofiX9L29+FkHsFOG9vj3YodBYwAqr1PcGf7l5DqNPIHOrOgZeS/a1jJLpiIfs+1GcdHcmI/XJReA=="
+    },
+    "@directus/drive": {
+      "version": "9.0.0-rc.40",
+      "resolved": "https://registry.npmjs.org/@directus/drive/-/drive-9.0.0-rc.40.tgz",
+      "integrity": "sha512-qs8j2UJhtrvH5SFk+YbecFlM9CDzWPDryQ4al9xlKLwsj26LlUalhxSPVTKUZBZnRNQZPIN7xdQIn6hB0oeWdg==",
+      "requires": {
+        "fs-extra": "^9.0.0",
+        "node-exceptions": "^4.0.1"
+      }
+    },
+    "@directus/drive-azure": {
+      "version": "9.0.0-rc.40",
+      "resolved": "https://registry.npmjs.org/@directus/drive-azure/-/drive-azure-9.0.0-rc.40.tgz",
+      "integrity": "sha512-pHoeWlDdch5UXZRBP18QBHIqN4itoOZkwvR96K/MIxzS5ZPpbUo/EEvTbOZ2LjLukxp8hF+5vcUgHtsnpzGu2g==",
+      "requires": {
+        "@azure/storage-blob": "^12.2.1"
+      }
+    },
+    "@directus/drive-gcs": {
+      "version": "9.0.0-rc.40",
+      "resolved": "https://registry.npmjs.org/@directus/drive-gcs/-/drive-gcs-9.0.0-rc.40.tgz",
+      "integrity": "sha512-LYHd6IshAL4JGfdE+9+hfOCIxf1vKxj/wUIu3A5I7q1LPOIm/ISVcmY6fkkIIinTL5znpy484FkJCmg4TXtWgw==",
+      "requires": {
+        "@google-cloud/storage": "^5.0.0"
+      }
+    },
+    "@directus/drive-s3": {
+      "version": "9.0.0-rc.40",
+      "resolved": "https://registry.npmjs.org/@directus/drive-s3/-/drive-s3-9.0.0-rc.40.tgz",
+      "integrity": "sha512-CM9gMsI2AO9togKLfsTRO52OpXuocFOUgDo1WekGSuWAQErJMThc2uUcXw9HCDaSnZ0DvldZDG4En+rztep5lQ==",
+      "requires": {
+        "aws-sdk": "^2.680.0"
       }
     },
     "@directus/format-title": {
-      "version": "9.0.0-rc.32",
-      "resolved": "https://registry.npmjs.org/@directus/format-title/-/format-title-9.0.0-rc.32.tgz",
-      "integrity": "sha512-PwEJ1RBpodCZlTQBJeHBGzku56FGPRn3k3ezjkPjP5JyVqP/1D2/ziXmVZgBZ+LQH0cYPhFTIVvgjHAyqtDY2Q=="
+      "version": "9.0.0-rc.40",
+      "resolved": "https://registry.npmjs.org/@directus/format-title/-/format-title-9.0.0-rc.40.tgz",
+      "integrity": "sha512-ffO0CFM2otGc+ey0io9HSduWLBdIIzPM/sPzDZJXrP900f7xBQ2WhLhapK2YpgilXkY9JHRTTLHmooKAFO8H+g=="
     },
     "@directus/schema": {
-      "version": "9.0.0-rc.32",
-      "resolved": "https://registry.npmjs.org/@directus/schema/-/schema-9.0.0-rc.32.tgz",
-      "integrity": "sha512-cDfPEfA+7HC1iidLLyV992zWllhfP249Y2wvgFG+Ljzy58HcY3ZWW1xvyABmpIC9iuNnTvwVdtQPyYX+NEYEjQ=="
+      "version": "9.0.0-rc.40",
+      "resolved": "https://registry.npmjs.org/@directus/schema/-/schema-9.0.0-rc.40.tgz",
+      "integrity": "sha512-gX2SfGKT8MBoWJ5PBIM76RYxB0Bz/p8z4qD30bWE/hHtp4GoXdS8HHft9/UHULhcAC1Lu/qWbOnmIGlgXIkodA=="
     },
     "@directus/specs": {
-      "version": "9.0.0-rc.32",
-      "resolved": "https://registry.npmjs.org/@directus/specs/-/specs-9.0.0-rc.32.tgz",
-      "integrity": "sha512-x0lnrhknGM2Vcd9KRxXm++T+CFR40NyGhPjyIT6xdMVjk9xjdkRt/sDAVEgnm/kCxjxcfGWiXj/7FMzUUoUqhQ=="
+      "version": "9.0.0-rc.40",
+      "resolved": "https://registry.npmjs.org/@directus/specs/-/specs-9.0.0-rc.40.tgz",
+      "integrity": "sha512-DDWUoMu4XMDjNUW7NMbRqzyXhL4ERuLrNhdH9+aPxf8NTRc6uGSkcQv5ldyc9KSQc7cLs79WYi0bX8q/fAqpoQ=="
     },
     "@godaddy/terminus": {
       "version": "4.6.0",
@@ -77,9 +240,9 @@
       }
     },
     "@google-cloud/common": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.5.0.tgz",
-      "integrity": "sha512-10d7ZAvKhq47L271AqvHEd8KzJqGU45TY+rwM2Z3JHuB070FeTi7oJJd7elfrnKaEvaktw3hH2wKnRWxk/3oWQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-3.6.0.tgz",
+      "integrity": "sha512-aHIFTqJZmeTNO9md8XxV+ywuvXF3xBm5WNmgWeeCK+XN5X+kGW0WEX94wGwj+/MdOnrVf4dL2RvSIt9J5yJG6Q==",
       "requires": {
         "@google-cloud/projectify": "^2.0.0",
         "@google-cloud/promisify": "^2.0.0",
@@ -87,7 +250,7 @@
         "duplexify": "^4.1.1",
         "ent": "^2.2.0",
         "extend": "^3.0.2",
-        "google-auth-library": "^6.1.1",
+        "google-auth-library": "^7.0.2",
         "retry-request": "^4.1.1",
         "teeny-request": "^7.0.0"
       }
@@ -112,11 +275,11 @@
       "integrity": "sha512-d4VSA86eL/AFTe5xtyZX+ePUjE8dIFu2T8zmdeNBSa5/kNgXPCx/o/wbFNHAGLJdGnk1vddRuMESD9HbOC8irw=="
     },
     "@google-cloud/storage": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.7.3.tgz",
-      "integrity": "sha512-1or09kfx8bmSMG5MvTCiuooCfS0btDtchvwQpIx/iF2IogzmFhLFFtmCeEpstTsfql6bHAnvN8Up7W5+9kMgdA==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-5.8.0.tgz",
+      "integrity": "sha512-WOShvBPOfkDXUzXMO+3j8Bzus+PFI9r1Ey9dLG2Zf458/PVuFTtaRWntd9ZiDG8g90zl2LmnA1JkDCreGUKr5g==",
       "requires": {
-        "@google-cloud/common": "^3.5.0",
+        "@google-cloud/common": "^3.6.0",
         "@google-cloud/paginator": "^3.0.0",
         "@google-cloud/promisify": "^2.0.0",
         "arrify": "^2.0.0",
@@ -126,7 +289,7 @@
         "duplexify": "^4.0.0",
         "extend": "^3.0.2",
         "gaxios": "^4.0.0",
-        "gcs-resumable-upload": "^3.1.0",
+        "gcs-resumable-upload": "^3.1.3",
         "get-stream": "^6.0.0",
         "hash-stream-validation": "^0.2.2",
         "mime": "^2.2.0",
@@ -180,6 +343,24 @@
         }
       }
     },
+    "@opencensus/web-types": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@opencensus/web-types/-/web-types-0.0.7.tgz",
+      "integrity": "sha512-xB+w7ZDAu3YBzqH44rCmG9/RlrOmFuDPt/bpf17eJr8eZSrLt7nc7LnWdxM9Mmoj/YKMHpxRg28txu3TcpiL+g=="
+    },
+    "@opentelemetry/api": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-0.10.2.tgz",
+      "integrity": "sha512-GtpMGd6vkzDMYcpu2t9LlhEgMy/SzBwRnz48EejlRArYqZzqSzAsKmegUK7zHgl+EOIaK9mKHhnRaQu3qw20cA==",
+      "requires": {
+        "@opentelemetry/context-base": "^0.10.2"
+      }
+    },
+    "@opentelemetry/context-base": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/context-base/-/context-base-0.10.2.tgz",
+      "integrity": "sha512-hZNKjKOYsckoOEgBziGMnBcX0M7EtstnCmwz5jZUOUYwlZ+/xxX6z3jPu1XVO2Jivk0eLfuP9GP+vFD49CMetw=="
+    },
     "@otplib/core": {
       "version": "12.0.1",
       "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
@@ -228,9 +409,9 @@
       "integrity": "sha512-m7X9U6BG2+J+R1lSOdCiITLLrxm+cWlNI3HUFA92oLO77ObGNzaKdh8pMLqdZcshtkKuV84olNNXDfMc4FezBQ=="
     },
     "@sideway/address": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.0.tgz",
-      "integrity": "sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.1.tgz",
+      "integrity": "sha512-+I5aaQr3m0OAmMr7RQ3fR9zx55sejEYR2BFJaxL+zT3VM2611X0SHvPWIbAUBZVTn/YzYKbV8gJ2oT/QELknfQ==",
       "requires": {
         "@hapi/hoek": "^9.0.0"
       }
@@ -245,41 +426,24 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
-    "@slynova/flydrive": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@slynova/flydrive/-/flydrive-1.0.3.tgz",
-      "integrity": "sha512-XJ8tfijqfXUuFPwrceCgXr/GqwkO49u4fBYsXZV7lBt9/9HqbdEG2E//R3pOIp2L35zqxrOe3Vk/getnYibjAA==",
-      "requires": {
-        "fs-extra": "^9.0.0",
-        "node-exceptions": "^4.0.1"
-      }
-    },
-    "@slynova/flydrive-gcs": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@slynova/flydrive-gcs/-/flydrive-gcs-1.0.3.tgz",
-      "integrity": "sha512-EsDfExQtpmeGNrgXdbgk1wEBeCb+f8skoK4Q5xT3l96CFWkmfDC/mkjjWfSjrlkqVWbwq+hwzt+Z9gNaElQ0qA==",
-      "requires": {
-        "@google-cloud/storage": "^5.0.0"
-      }
-    },
-    "@slynova/flydrive-s3": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@slynova/flydrive-s3/-/flydrive-s3-1.0.3.tgz",
-      "integrity": "sha512-mSLuQ+YqJTlW+64D+bVKQCF0W8FKKAeOkhrWWc7NIE35AWxrI7eLbaOBqe1GHBiy29xRP8v+aHGMIelGsi1bDQ==",
-      "requires": {
-        "aws-sdk": "^2.680.0"
-      }
-    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw=="
     },
     "@types/node": {
-      "version": "12.19.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.15.tgz",
-      "integrity": "sha512-lowukE3GUI+VSYSu6VcBXl14d61Rp5hA1D+61r16qnwC0lYNSqdxcvRh0pswejorHfS+HgwBasM8jLXz0/aOsw==",
-      "optional": true
+      "version": "14.14.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.28.tgz",
+      "integrity": "sha512-lg55ArB+ZiHHbBBttLpzD07akz0QPrZgUODNakeC09i62dnrywr9mFErHuaPlB6I7z+sEbK+IYmplahvplCj2g=="
+    },
+    "@types/node-fetch": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      }
     },
     "@types/readable-stream": {
       "version": "2.3.9",
@@ -292,10 +456,9 @@
       }
     },
     "@types/tunnel": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.0.tgz",
-      "integrity": "sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==",
-      "optional": true,
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
       "requires": {
         "@types/node": "*"
       }
@@ -566,8 +729,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "optional": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -585,9 +747,9 @@
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
     },
     "aws-sdk": {
-      "version": "2.831.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.831.0.tgz",
-      "integrity": "sha512-lrOjbGFpjk2xpESyUx2PGsTZgptCy5xycZazPeakNbFO19cOoxjHx3xyxOHsMCYb3pQwns35UvChQT60B4u6cw==",
+      "version": "2.846.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.846.0.tgz",
+      "integrity": "sha512-r/VUmo7Ri4yxVonFARzb9reZgcURbddfKur5HlAG55Xd4ku3u7akMe/rZYFuhQbUTef6p6J19oUg/W+fnEY2Tw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -600,10 +762,34 @@
         "xml2js": "0.4.19"
       },
       "dependencies": {
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        },
         "uuid": {
           "version": "3.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
           "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        },
+        "xml2js": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+          "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+          "requires": {
+            "sax": ">=0.6.0",
+            "xmlbuilder": "~9.0.1"
+          }
+        },
+        "xmlbuilder": {
+          "version": "9.0.7",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+          "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         }
       }
     },
@@ -1002,7 +1188,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1142,9 +1327,9 @@
       "integrity": "sha512-EFTCh9zRSEpGPmJaexg7HTuzZHh6cnJj1ui7IGCFNXzd2QdpsNh05Db5TF3xzJm30YN+A8/6xHSuRcQqoc3kFA=="
     },
     "date-fns": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
-      "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.17.0.tgz",
+      "integrity": "sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA=="
     },
     "date-utils": {
       "version": "1.2.21",
@@ -1192,6 +1377,13 @@
       "requires": {
         "lodash": "^4.17.11",
         "tslib": "^1.6.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "defaults": {
@@ -1242,8 +1434,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "optional": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -1285,19 +1476,20 @@
       }
     },
     "directus": {
-      "version": "9.0.0-rc.32",
-      "resolved": "https://registry.npmjs.org/directus/-/directus-9.0.0-rc.32.tgz",
-      "integrity": "sha512-vej0MJYWFrCVgP3c9w83BrOxaQ6g3W4g1PLr2FtFh5mJXO2PvRXyac+DdwjVSXX0KcTv8t1bzmaJLjmHm2NeNQ==",
+      "version": "9.0.0-rc.40",
+      "resolved": "https://registry.npmjs.org/directus/-/directus-9.0.0-rc.40.tgz",
+      "integrity": "sha512-OA8DWZ4rzSh7bYaiiavanYlG0OOfjieiDSOLhrCBpLM7WEedH6Vkwt5MU+e8qu0H2SJC3H5I8WwoC2hwMiykhA==",
       "requires": {
-        "@directus/app": "^9.0.0-rc.32",
-        "@directus/format-title": "^9.0.0-rc.32",
-        "@directus/schema": "^9.0.0-rc.32",
-        "@directus/specs": "^9.0.0-rc.32",
+        "@directus/app": "^9.0.0-rc.40",
+        "@directus/drive": "^9.0.0-rc.40",
+        "@directus/drive-azure": "^9.0.0-rc.40",
+        "@directus/drive-gcs": "^9.0.0-rc.40",
+        "@directus/drive-s3": "^9.0.0-rc.40",
+        "@directus/format-title": "^9.0.0-rc.40",
+        "@directus/schema": "^9.0.0-rc.40",
+        "@directus/specs": "^9.0.0-rc.40",
         "@godaddy/terminus": "^4.4.1",
         "@keyv/redis": "^2.1.2",
-        "@slynova/flydrive": "^1.0.3",
-        "@slynova/flydrive-gcs": "^1.0.3",
-        "@slynova/flydrive-s3": "^1.0.3",
         "argon2": "^0.27.0",
         "atob": "^2.1.2",
         "axios": "^0.21.0",
@@ -1407,18 +1599,18 @@
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "elliptic": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+      "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
       "optional": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
+        "bn.js": "^4.11.9",
+        "brorand": "^1.1.0",
         "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "hmac-drbg": "^1.0.1",
+        "inherits": "^2.0.4",
+        "minimalistic-assert": "^1.0.1",
+        "minimalistic-crypto-utils": "^1.0.1"
       }
     },
     "emoji-regex": {
@@ -1480,9 +1672,9 @@
       "integrity": "sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ=="
     },
     "events": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+      "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
     },
     "execa": {
       "version": "4.1.0",
@@ -1880,6 +2072,13 @@
       "integrity": "sha1-9K8+qfNNiicc9YrSs3WfQx8LMY0=",
       "requires": {
         "punycode": "^1.3.2"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+        }
       }
     },
     "figures": {
@@ -1998,13 +2197,12 @@
       "optional": true
     },
     "form-data": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
-      "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-      "optional": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
       "requires": {
         "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
+        "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
       }
     },
@@ -2109,15 +2307,15 @@
       }
     },
     "gcs-resumable-upload": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.2.tgz",
-      "integrity": "sha512-VKWP3Xju1JmNX3N4ossnGp3DfIRZjOsMj8sDGPBGnvn8YSruCOVGQBvELfStfIFPybScv/e5sEdWx/qzfnS3+w==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-3.1.3.tgz",
+      "integrity": "sha512-LjVrv6YVH0XqBr/iBW0JgRA1ndxhK6zfEFFJR4im51QVTj/4sInOXimY2evDZuSZ75D3bHxTaQAdXRukMc1y+w==",
       "requires": {
         "abort-controller": "^3.0.0",
         "configstore": "^5.0.0",
         "extend": "^3.0.2",
         "gaxios": "^4.0.0",
-        "google-auth-library": "^6.0.0",
+        "google-auth-library": "^7.0.0",
         "pumpify": "^2.0.0",
         "stream-events": "^1.0.4"
       }
@@ -2197,9 +2395,9 @@
       }
     },
     "google-auth-library": {
-      "version": "6.1.5",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.5.tgz",
-      "integrity": "sha512-vlizrMSlHIu6blPtSC9AJZ1xYQWqUp1xqhcMzYff+hNKTSqVlsynMQIE8BdCo/FhPib4U1fvv1gnczMDHB2Wmg==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-7.0.2.tgz",
+      "integrity": "sha512-vjyNZR3pDLC0u7GHLfj+Hw9tGprrJwoMwkYGqURCXYITjCrP9HprOyxVV+KekdLgATtWGuDkQG2MTh0qpUPUgg==",
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
@@ -2221,9 +2419,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "grant": {
       "version": "5.4.9",
@@ -2254,9 +2452,9 @@
       }
     },
     "graphql": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.4.0.tgz",
-      "integrity": "sha512-EB3zgGchcabbsU9cFe1j+yxdzKQKAbGUWRb13DsrsMN1yyfmmIq+2+L5MqVWcDCE4V89R5AyUOi7sMOGxdsYtA=="
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
     },
     "graphql-type-json": {
       "version": "0.3.2",
@@ -2264,14 +2462,13 @@
       "integrity": "sha512-J+vjof74oMlCWXSvt0DOf2APEdZOCdubEvGDUAlqH//VBYcOYsGgRW7Xzorr44LvkjiuvecWc8fChxuZZbChtg=="
     },
     "gtoken": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.0.tgz",
-      "integrity": "sha512-qbf6JWEYFMj3WMAluvYXl8GAiji6w8d9OmAGCbBg0xF4xD/yu6ZaO6BhoXNddRjKcOUpZD81iea1H5B45gAo1g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
       "requires": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
-        "jws": "^4.0.0",
-        "mime": "^2.2.0"
+        "jws": "^4.0.0"
       }
     },
     "har-schema": {
@@ -2541,9 +2738,9 @@
       "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw=="
     },
     "ioredis": {
-      "version": "4.19.4",
-      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.19.4.tgz",
-      "integrity": "sha512-3haQWw9dpEjcfVcRktXlayVNrrqvvc2io7Q/uiV2UsYw8/HC2YwwJr78Wql7zu5bzwci0x9bZYA69U7KkevAvw==",
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-4.22.0.tgz",
+      "integrity": "sha512-mtC+jNFMPRxReWx0HodDbcwj34Gj5pK/P4+aE6Nh0pdqgtZKvxUh4z2lVtLjqnRIvMhKaBnIgMYFR8qH/xtttA==",
       "optional": true,
       "requires": {
         "cluster-key-slot": "^1.1.0",
@@ -2552,16 +2749,16 @@
         "lodash.defaults": "^4.2.0",
         "lodash.flatten": "^4.4.0",
         "p-map": "^2.1.0",
-        "redis-commands": "1.6.0",
+        "redis-commands": "1.7.0",
         "redis-errors": "^1.2.0",
         "redis-parser": "^3.0.0",
         "standard-as-callback": "^2.0.1"
       },
       "dependencies": {
         "redis-commands": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.6.0.tgz",
-          "integrity": "sha512-2jnZ0IkjZxvguITjFTrGiLyzQZcTvaw8DAaCXxZq/dsHXz7KfMQ3OUJy7Tz9vnRtZRVz6VRCPDvruvU8Ts44wQ==",
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/redis-commands/-/redis-commands-1.7.0.tgz",
+          "integrity": "sha512-nJWqw3bTFy21hX/CPKHth6sfhZbdiHP6bTawSgQBlKOVRG7EZkfHbbHwQJnrE4vsQf0CMNE+3gJ4Fmm16vdVlQ==",
           "optional": true
         }
       }
@@ -2788,9 +2985,9 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
     "joi": {
-      "version": "17.3.0",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.3.0.tgz",
-      "integrity": "sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==",
+      "version": "17.4.0",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.4.0.tgz",
+      "integrity": "sha512-F4WiW2xaV6wc1jxete70Rw4V/VuMd6IN+a5ilZsxG4uYtUXWu2kq9W5P2dz30e7Gmw8RCbY/u/uk+dMPma9tAg==",
       "requires": {
         "@hapi/hoek": "^9.0.0",
         "@hapi/topo": "^5.0.0",
@@ -2852,9 +3049,9 @@
       "optional": true
     },
     "json2csv": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.5.tgz",
-      "integrity": "sha512-/UyvnfuUghRM+C/AiQ02X0LS+/AKfugcwaWo/gAz1pi203v29sUMrMSNEC088i+h0EG39eSsmeL9Z0iK+9MM0A==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/json2csv/-/json2csv-5.0.6.tgz",
+      "integrity": "sha512-0/4Lv6IenJV0qj2oBdgPIAmFiKKnh8qh7bmLFJ+/ZZHLjSeiL3fKKGX3UryvKPbxFbhV+JcYo9KUC19GJ/Z/4A==",
       "requires": {
         "commander": "^6.1.0",
         "jsonparse": "^1.3.1",
@@ -2969,13 +3166,13 @@
       }
     },
     "keyv-memcache": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/keyv-memcache/-/keyv-memcache-1.0.2.tgz",
-      "integrity": "sha512-nTmRUArJKOF0TEba5S16EXgTVWxdQEUA0ld2TYEtuZIG3JPEsI9p7h2lHBwlMEocVRFG4r9v7ozG8rQ92VUIyg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/keyv-memcache/-/keyv-memcache-1.2.4.tgz",
+      "integrity": "sha512-HNY/KL07YC44a8nkfKxYyIXCnMA4ng0vEfPWSYomKMnanY7sxqdbv6Ei9zzn22uVLganphZ/flAC4tPVen3+dg==",
       "optional": true,
       "requires": {
         "json-buffer": "^3.0.1",
-        "memjs": "^1.2.2"
+        "memjs": "^1.3.0"
       }
     },
     "kind-of": {
@@ -2984,9 +3181,9 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
     },
     "knex": {
-      "version": "0.21.16",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.21.16.tgz",
-      "integrity": "sha512-M3FTFfby49AEngsx/0UXEJEMnKMjPjeKOtvk+AY6d6kboz9NsT7xDudl0wRNj+S0lq0yearCSb1v+YxgbU/kWA==",
+      "version": "0.21.17",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.21.17.tgz",
+      "integrity": "sha512-kAt58lRwjzqwedApKF7luYPa7HsLb0oDiczwKrkZcekIzTmSow5YGK149S2C8HjH63R3NcOBo9+1rjvWnC1Paw==",
       "requires": {
         "colorette": "1.2.1",
         "commander": "^6.2.0",
@@ -3018,9 +3215,9 @@
       }
     },
     "liquidjs": {
-      "version": "9.20.1",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.20.1.tgz",
-      "integrity": "sha512-pXXraZ6wKhSuTwLVtoQ9iOgayeKhR6J9PP9IqELGox2BbJ2MlQkDPO1HNCWZDHDVFbddtnb5ZIhxCFUjkZQ10w=="
+      "version": "9.23.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-9.23.0.tgz",
+      "integrity": "sha512-4yaOYWNIIErClIX87kyYoYkgCzVk6bZpiY3fX2r5xM8xJ50tUNiXohcQ24ajxslkCAPOXW5ZSYu6KLKURXjavw=="
     },
     "lodash": {
       "version": "4.17.20",
@@ -3186,21 +3383,21 @@
       }
     },
     "mime": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.0.tgz",
-      "integrity": "sha512-ft3WayFSFUVBuJj7BMLKAQcSlItKtfjsKDDsii3rqFDAZ7t11zRe8ASw/GlmivGwVUYtwkQrxiGGpL6gFvB0ag=="
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
+      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg=="
     },
     "mime-db": {
-      "version": "1.45.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-      "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w=="
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+      "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ=="
     },
     "mime-types": {
-      "version": "2.1.28",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-      "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+      "version": "2.1.29",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+      "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
       "requires": {
-        "mime-db": "1.45.0"
+        "mime-db": "1.46.0"
       }
     },
     "mimic-fn": {
@@ -3424,11 +3621,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "sax": {
-          "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         }
       }
     },
@@ -3559,9 +3751,9 @@
       }
     },
     "nodemailer": {
-      "version": "6.4.17",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.17.tgz",
-      "integrity": "sha512-89ps+SBGpo0D4Bi5ZrxcrCiRFaMmkCt+gItMXQGzEtZVR3uAD3QAQIDoxTWnx3ky0Dwwy/dhFrQ+6NNGXpw/qQ=="
+      "version": "6.4.18",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.4.18.tgz",
+      "integrity": "sha512-ht9cXxQ+lTC+t00vkSIpKHIyM4aXIsQ1tcbQCn5IOnxYHi81W2XOaU66EQBFFpbtzLEBTC94gmkbD4mGZQzVpA=="
     },
     "noop-logger": {
       "version": "0.1.1",
@@ -3761,9 +3953,9 @@
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
         "bl": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
           "requires": {
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
@@ -3990,9 +4182,9 @@
       }
     },
     "pino": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.0.tgz",
-      "integrity": "sha512-VPqEE2sU1z6wqkTtr7DdTktayTNE/JgeuWjfXh9g/TI6X7venzv4gaoU24/jSywf6bBeDfZRHWEeO/6f8bNppA==",
+      "version": "6.11.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.11.1.tgz",
+      "integrity": "sha512-PoDR/4jCyaP1k2zhuQ4N0NuhaMtei+C9mUHBRRJQujexl/bq3JkeL2OC23ada6Np3zeUMHbO4TGzY2D/rwZX3w==",
       "requires": {
         "fast-redact": "^3.0.0",
         "fast-safe-stringify": "^2.0.7",
@@ -4035,9 +4227,9 @@
       }
     },
     "pino-http": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.3.0.tgz",
-      "integrity": "sha512-aV4e7L8ez2MCa1qsuuliKYX5CDJug3LjW8oht+r4H4+fcf7ZvxPOppTs7P9dNHccF8k8oqhOcU/myiP4GvzJiA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/pino-http/-/pino-http-5.5.0.tgz",
+      "integrity": "sha512-ZXhWeYhUisf9oZdS54XaBTrNVzZ7p61/sw0RpwCdU1vI/qdGWvSG4QUA5qU5Y5ya47ch3kM3HTcZf/QB5SCtNw==",
       "requires": {
         "fast-url-parser": "^1.1.3",
         "pino": "^6.0.0",
@@ -4078,9 +4270,9 @@
       }
     },
     "prebuild-install": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.0.tgz",
-      "integrity": "sha512-h2ZJ1PXHKWZpp1caLw0oX9sagVpL2YTk+ZwInQbQ3QqNd4J03O6MpFNmMTJlkfgPENWqe5kP0WjQLqz5OjLfsw==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+      "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
@@ -4124,6 +4316,11 @@
         "parse-ms": "^2.1.0"
       }
     },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+    },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -4141,8 +4338,7 @@
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-      "optional": true
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
     },
     "pump": {
       "version": "3.0.0",
@@ -4164,9 +4360,9 @@
       }
     },
     "punycode": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.9.6",
@@ -4323,6 +4519,16 @@
           "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
           "optional": true
         },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "optional": true,
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        },
         "uuid": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -4347,11 +4553,11 @@
       }
     },
     "resolve": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
-      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+      "integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
       "requires": {
-        "is-core-module": "^2.1.0",
+        "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"
       }
     },
@@ -4428,6 +4634,13 @@
       "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
       "requires": {
         "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "safe-buffer": {
@@ -4449,9 +4662,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sax": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "semver": {
       "version": "6.3.0",
@@ -4757,9 +4970,9 @@
       }
     },
     "sonic-boom": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.0.tgz",
-      "integrity": "sha512-4nX6OYvOYr6R76xfQKi6cZpTO3YSWe/vd+QdIfoH0lBy0MnPkeAbb2rRWgmgADkXUeCKPwO1FZAKlAVWAadELw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.3.2.tgz",
+      "integrity": "sha512-/B4tAuK2+hIlR94GhhWU1mJHWk5lt0CEuBvG0kvk1qIAzQc4iB1TieMio8DCZxY+Y7tsuzOxSUDOGmaUm3vXMg==",
       "requires": {
         "atomic-sleep": "^1.0.0",
         "flatstr": "^1.0.12"
@@ -4783,9 +4996,9 @@
       }
     },
     "source-map-url": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
     },
     "split-string": {
       "version": "3.1.0",
@@ -5021,9 +5234,9 @@
       },
       "dependencies": {
         "bl": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
-          "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
           "requires": {
             "buffer": "^5.5.0",
             "inherits": "^2.0.4",
@@ -5065,6 +5278,12 @@
         "sprintf-js": "^1.1.2"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "12.20.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.1.tgz",
+          "integrity": "sha512-tCkE96/ZTO+cWbln2xfyvd6ngHLanvVlJ3e5BeirJ3BYI5GbAyubIrmV4JjjugDly5D9fHjOL5MNsqsCnqwW6g==",
+          "optional": true
+        },
         "depd": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -5079,12 +5298,6 @@
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
-        },
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-          "optional": true
         },
         "sprintf-js": {
           "version": "1.1.2",
@@ -5173,33 +5386,31 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
     },
     "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "optional": true,
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
       "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
       },
       "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-          "optional": true
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
         }
       }
     },
     "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+      "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
     "tunnel": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
-      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "optional": true
+      "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -5328,14 +5539,6 @@
       "optional": true,
       "requires": {
         "punycode": "^2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-          "optional": true
-        }
       }
     },
     "urix": {
@@ -5350,6 +5553,13 @@
       "requires": {
         "punycode": "1.3.2",
         "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
       }
     },
     "use": {
@@ -5452,18 +5662,18 @@
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
     },
     "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
       "requires": {
         "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
+        "xmlbuilder": "~11.0.0"
       }
     },
     "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmldom": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "directus": "^9.0.0-rc.31",
+    "directus": "^9.0.0-rc.40",
     "pg": "^8.5.1"
   }
 }


### PR DESCRIPTION
This updates Directus to last rc.40, and uses `bootstrap` command instead of roles/users command to provision the initial user.

I'm not sure about the logging section though. I feel like it should be rephrased, but since I'm not sure how platform.sh works in that regard, I'd love some guidance on what to do there.

Thank you!